### PR TITLE
fixed frame counter

### DIFF
--- a/tracklab/utils/cv2.py
+++ b/tracklab/utils/cv2.py
@@ -279,7 +279,7 @@ def draw_ignore_region(patch, image_metadata):
 def print_count_frame(patch, frame, nframes):
     draw_text(
         patch,
-        f"{frame}/{nframes}",
+        f"{frame+1}/{nframes}",
         (6, 15),
         fontFace=1,
         fontScale=2.0,


### PR DESCRIPTION
The frame counter on top left of the image is starting from **0 to N_frames-1** so when the video finishes the counter is displaying : **N_frames-1/N_frames**. Now corrected to **N_frames/N_frames**.