### PR TITLE
utils/cv2: use rsplit in cv2_load_image so Windows drive-letter paths work

### DIFF
--- a/tracklab/utils/cv2.py
+++ b/tracklab/utils/cv2.py
@@ -56,7 +56,7 @@ def cv2_load_image(file_path):
     file_path = str(file_path)
     if file_path.startswith("vid://"):
         file_path = file_path.removeprefix("vid://")
-        video_file, frame_id = file_path.split(":")
+        video_file, frame_id = file_path.rsplit(":", 1)
         if video_reader.filename != video_file:
             video_reader.set_filename(video_file)
         image = video_reader[int(frame_id)]


### PR DESCRIPTION
## Summary

`cv2_load_image` in `tracklab/utils/cv2.py` parses a `vid://<path>:<frame_id>` URI with `str.split(":")`. On Windows, paths contain a drive-letter colon (e.g. `C:/Users/.../clip.mp4`), so the URI `vid://C:/Users/me/clip.mp4:0` splits into **three** pieces and the tuple unpack raises `ValueError`.

Using `rsplit(":", 1)` cleaves only the trailing `:<frame_id>` and leaves the rest of the path intact. It works identically on POSIX (no change in behaviour) and fixes Windows.

## Reproduction (POSIX shell, same bug a Windows user hits)

```python
>>> "C:/Users/me/clip.mp4:0".split(":")
['C', '/Users/me/clip.mp4', '0']          # 3 pieces → ValueError on unpack
>>> "C:/Users/me/clip.mp4:0".rsplit(":", 1)
['C:/Users/me/clip.mp4', '0']             # correct
```

Any Windows user loading frames through the `vid://` scheme (ExternalVideo wrapper, `dataset=video` configs, the video reader path in image-level pipelines) hits it:

```
File ".../tracklab/utils/cv2.py", line 59, in cv2_load_image
    video_file, frame_id = file_path.split(":")
ValueError: too many values to unpack (expected 2)
```

## Change

One line in `tracklab/utils/cv2.py`:

```diff
-        video_file, frame_id = file_path.split(":")
+        video_file, frame_id = file_path.rsplit(":", 1)
```

## Risk

None on POSIX — `rsplit(":", 1)` on a single-colon string returns the same 2-tuple as `split(":")`. The only behavioural change is that multi-colon strings now parse as "everything up to the last colon is the path, the tail is the frame id", which is the intended semantics.

## Context

Encountered while running `sn-gamestate` on a workstation pair (Linux + Windows) for a Blackwell-GPU compatibility sweep. Filing alongside a sibling PR to `SoccerNet/sn-gamestate` for a related pandas-2 `.iloc[0]` fix; both were needed to get the pipeline end-to-end on a mixed-OS setup.
